### PR TITLE
Website updates

### DIFF
--- a/packages.qmd
+++ b/packages.qmd
@@ -51,6 +51,39 @@ packages %>% glue_data('- [{full_name}]({html_url}) {description}', close='\n')
 
 ## gsm.core 
 
-- 
+```{r get_gsm_articles, echo=FALSE, results = "asis"}
+get_articles <- function(pkg) {
+    url <- paste0("https://api.github.com/repos/Gilead-BioStats/",pkg,"/contents/vignettes")
+    response <- GET(url)
+    content <- content(response, as = "text")
+    json <- fromJSON(content) %>%
+      dplyr::filter(grepl("Rmd", name))
+    return(json)
+}
+gsm_articles <- get_articles("gsm")
+articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
+names(articles) <- gsm_articles$name
+
+##grab names, descriptions and links into a table
+get_meta <- function(article, field) {
+  field_line <- article[grep(paste0(field,": "), article)[1]]
+  if(length(field_line) > 0) {
+    clean_field <- gsub(paste0(field,": "), "", field_line)
+    clean_field <- gsub('\"', "", clean_field)
+  } else {
+    clean_field <- NA
+  }
+  return(clean_field)
+}
+
+purrr::map(names(articles), \(.x) {
+  gsm_articles$description[gsm_articles$name == .x] <<- get_meta(articles[[.x]], 
+                                                                        "description")
+  gsm_articles$title[gsm_articles$name == .x] <<- get_meta(articles[[.x]],
+                                                                  "title")
+})
+
+gsm_articles %>% glue_data('- [{title}](https://gilead-biostats.github.io/gsm/articles/{name}) {description}', close='\n')
+```
 
 # Examples

--- a/packages.qmd
+++ b/packages.qmd
@@ -44,14 +44,7 @@ packages %>% glue_data('- [{full_name}]({html_url}) {description}', close='\n')
 
 # Articles
 
-## OpenRBQM
-
-- Intro to OpenRBQM
-- Data Model Overview
-
-## gsm.core 
-
-```{r get_gsm_articles, echo=FALSE, results = "asis"}
+```{r define article functions, echo=FALSE, results = "asis"}
 get_articles <- function(pkg) {
     url <- paste0("https://api.github.com/repos/Gilead-BioStats/",pkg,"/contents/vignettes")
     response <- GET(url)
@@ -60,11 +53,7 @@ get_articles <- function(pkg) {
       dplyr::filter(grepl("Rmd", name))
     return(json)
 }
-gsm_articles <- get_articles("gsm")
-articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
-names(articles) <- gsm_articles$name
 
-##grab names, descriptions and links into a table
 get_meta <- function(article, field) {
   field_line <- article[grep(paste0(field,": "), article)[1]]
   if(length(field_line) > 0) {
@@ -75,7 +64,24 @@ get_meta <- function(article, field) {
   }
   return(clean_field)
 }
+```
 
+## OpenRBQM
+
+- Intro to OpenRBQM
+- Data Model Overview
+
+## gsm.core 
+
+```{r get_gsm_articles, echo=FALSE, results = "asis"}
+
+gsm_articles <- get_articles("gsm")
+
+#get article text
+articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
+names(articles) <- gsm_articles$name
+
+#add title and description to data
 purrr::map(names(articles), \(.x) {
   gsm_articles$description[gsm_articles$name == .x] <<- get_meta(articles[[.x]], 
                                                                         "description")
@@ -83,6 +89,7 @@ purrr::map(names(articles), \(.x) {
                                                                   "title")
 })
 
+##output names, descriptions and links
 gsm_articles %>% glue_data('- [{title}](https://gilead-biostats.github.io/gsm/articles/{name}) {description}', close='\n')
 ```
 

--- a/packages.qmd
+++ b/packages.qmd
@@ -45,8 +45,8 @@ packages %>% glue_data('- [{full_name}]({html_url}) {description}', close='\n')
 # Articles
 
 ```{r define article functions, echo=FALSE, results = "asis"}
-get_articles <- function(pkg) {
-    url <- paste0("https://api.github.com/repos/Gilead-BioStats/",pkg,"/contents/vignettes")
+get_articles <- function(repo, pkg) {
+    url <- paste0("https://api.github.com/repos/",repo,"/",pkg,"/contents/vignettes")
     response <- GET(url)
     content <- content(response, as = "text")
     json <- fromJSON(content) %>%
@@ -68,14 +68,31 @@ get_meta <- function(article, field) {
 
 ## OpenRBQM
 
-- Intro to OpenRBQM
-- Data Model Overview
+```{r get_openrbqm_articles, echo=FALSE, results = "asis"}
+
+openrbqm_articles <- get_articles("OpenRBQM","openrbqm")
+
+#get article text
+articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
+names(articles) <- gsm_articles$name
+
+#add title and description to data
+purrr::map(names(articles), \(.x) {
+  gsm_articles$description[gsm_articles$name == .x] <<- get_meta(articles[[.x]], 
+                                                                        "description")
+  gsm_articles$title[gsm_articles$name == .x] <<- get_meta(articles[[.x]],
+                                                                  "title")
+})
+
+##output names, descriptions and links
+gsm_articles %>% glue_data('- [{title}](https://openrbqm.github.io/openrbqm/articles/{name}) {description}', close='\n')
+```
 
 ## gsm.core 
 
 ```{r get_gsm_articles, echo=FALSE, results = "asis"}
 
-gsm_articles <- get_articles("gsm")
+gsm_articles <- get_articles("Gilead-BioStats","gsm")
 
 #get article text
 articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))

--- a/packages.qmd
+++ b/packages.qmd
@@ -38,8 +38,9 @@ orgs <- c("openrbqm", "gilead-biostats")
 
 # Get packages from each repository
 packages <- orgs %>% map(get_packages) %>% bind_rows
+packages$description[is.na(packages$description)] <- "No Description Provided"
    
-packages %>% glue_data('- [{full_name}]({html_url}) {description}', close='\n')
+packages %>% glue_data('- [{full_name}]({html_url}): *{description}*', close='\n')
 
 ```
 
@@ -86,35 +87,49 @@ get_pkgdown_url <- function(org, repo) {
 
 
 ```{r get_articles, echo=FALSE, results = "asis"}
-for(i in 1:nrow(packages)) {
-  org <- strsplit(packages$full_name[i], split = "/")[[1]][1]
-  repo <- strsplit(packages$full_name[i], split = "/")[[1]][2]
-  
-  homepage_link <- get_pkgdown_url(org,repo)
-  cat(glue::glue("\n\n## {packages$full_name[i]} \n\n [{repo} Website]({homepage_link})\n\n"))
+packages_clean <- packages %>%
+  filter(grepl("/", full_name)) %>%  # remove malformed full_name entries
+  mutate(
+    org = map_chr(full_name, ~ strsplit(.x, "/")[[1]][1]),
+    repo = map_chr(full_name, ~ strsplit(.x, "/")[[1]][2])
+  ) %>% 
+  select(full_name, org, repo)
+
+# Iterate using pwalk
+pwalk(packages_clean, function(full_name, org, repo, ...) {
+  # Print header with appropriate spacing
+  homepage_link <- get_pkgdown_url(org, repo)
+  cat(glue("\n\n## {full_name} \n\n [{repo} Website]({homepage_link})\n\n"))
+  cat("\n\n")
   
   articles_meta <- get_articles(org, repo)
-  
-  if(is.data.frame(articles_meta)) {
-    #get article text
-    articles <- purrr::map(articles_meta$download_url, \(.x) readLines(.x))
+
+  if (is.data.frame(articles_meta)) {
+    articles <- map(articles_meta$download_url, readLines)
     names(articles) <- articles_meta$name
-    
-    #add title and description to data
-    header_info <- purrr::map(names(articles), \(.x) {
-      articles_meta$description[articles_meta$name == .x] <<- get_meta(articles[[.x]], 
-                                                                       "description")
-      articles_meta$title[articles_meta$name == .x] <<- get_meta(articles[[.x]],
-                                                                 "title")
-      articles_meta$homepage_link <- homepage_link
-    })
-    
-    ##output names, descriptions and links
-    articles_meta %>% glue_data('- [{title}]({homepage_link}}/articles/{name_html}) {description}\n\n') %>% cat()
+
+    # Add metadata
+    articles_meta$title <- map2_chr(articles_meta$name, articles, ~ get_meta(.y, "title"))
+    articles_meta$description <- map2_chr(articles_meta$name, articles, ~ get_meta(.y, "description"))
+    articles_meta$homepage_link <- homepage_link
+
+    # Derive name_html if needed
+    if (!"name_html" %in% colnames(articles_meta)) {
+      articles_meta$name_html <- articles_meta$name
+    }
+
+    # Output
+    glue_data(
+      articles_meta,
+      '- [{title}]({homepage_link}articles/{name_html}) {description}'
+    ) %>% cat(sep = "\n\n")
+  } else {
+    cat(articles_meta, sep = "\n")
   }
-  else{
-    cat(articles_meta)
-  }
-  }
+})
 
 ```
+
+# Examples
+
+Under Construction

--- a/packages.qmd
+++ b/packages.qmd
@@ -25,8 +25,9 @@ The OpenRBQM framework is designed to provide a robust and flexible solution for
 
 # Function to get package names from a GitHub repository
 get_packages <- function(org) {
-    url <- paste0("https://api.github.com/orgs/", org, "/repos")
-    response <- GET(url)
+    url <- paste0("https://api.github.com/orgs/", org, "/repos?type=public")
+    response <- GET(url,
+                    httr::authenticate("lauramaxwell", Sys.getenv("GITHUB_PAT")))
     content <- content(response, as = "text")
     json <- fromJSON(content)
     return(json)
@@ -42,16 +43,23 @@ packages %>% glue_data('- [{full_name}]({html_url}) {description}', close='\n')
 
 ```
 
-# Articles
+# Package Documentation
 
 ```{r define article functions, echo=FALSE, results = "asis"}
-get_articles <- function(repo, pkg) {
-    url <- paste0("https://api.github.com/repos/",repo,"/",pkg,"/contents/vignettes")
-    response <- GET(url)
+get_articles <- function(org, repo) {
+    url <- paste0("https://api.github.com/repos/",org,"/",repo,"/contents/vignettes")
+    response <- GET(url,
+                    httr::authenticate("lauramaxwell", Sys.getenv("GITHUB_PAT")))
+    if (response$status_code == 200) {
     content <- content(response, as = "text")
     json <- fromJSON(content) %>%
-      dplyr::filter(grepl("Rmd", name))
+      dplyr::filter(grepl("Rmd", name)) %>%
+      dplyr::mutate(name_html = gsub("Rmd", "html", name))
     return(json)
+    }
+    else{
+      return("No articles to display for this repository\n\n")
+    }
 }
 
 get_meta <- function(article, field) {
@@ -64,50 +72,49 @@ get_meta <- function(article, field) {
   }
   return(clean_field)
 }
+
+get_pkgdown_url <- function(org, repo) {
+  url <- paste0("https://api.github.com/repos/",org,"/",repo)
+    response <- GET(url,
+                    httr::authenticate("lauramaxwell", Sys.getenv("GITHUB_PAT")))
+    content <- content(response, as = "text")
+    json <- fromJSON(content)
+    return(json$homepage)
+}
 ```
 
-## OpenRBQM
 
-```{r get_openrbqm_articles, echo=FALSE, results = "asis"}
 
-openrbqm_articles <- get_articles("OpenRBQM","openrbqm")
+```{r get_articles, echo=FALSE, results = "asis"}
+for(i in 1:nrow(packages)) {
+  org <- strsplit(packages$full_name[i], split = "/")[[1]][1]
+  repo <- strsplit(packages$full_name[i], split = "/")[[1]][2]
+  
+  homepage_link <- get_pkgdown_url(org,repo)
+  cat(glue::glue("\n\n## {packages$full_name[i]} \n\n [{repo} Website]({homepage_link})\n\n"))
+  
+  articles_meta <- get_articles(org, repo)
+  
+  if(is.data.frame(articles_meta)) {
+    #get article text
+    articles <- purrr::map(articles_meta$download_url, \(.x) readLines(.x))
+    names(articles) <- articles_meta$name
+    
+    #add title and description to data
+    header_info <- purrr::map(names(articles), \(.x) {
+      articles_meta$description[articles_meta$name == .x] <<- get_meta(articles[[.x]], 
+                                                                       "description")
+      articles_meta$title[articles_meta$name == .x] <<- get_meta(articles[[.x]],
+                                                                 "title")
+      articles_meta$homepage_link <- homepage_link
+    })
+    
+    ##output names, descriptions and links
+    articles_meta %>% glue_data('- [{title}]({homepage_link}}/articles/{name_html}) {description}\n\n') %>% cat()
+  }
+  else{
+    cat(articles_meta)
+  }
+  }
 
-#get article text
-articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
-names(articles) <- gsm_articles$name
-
-#add title and description to data
-purrr::map(names(articles), \(.x) {
-  gsm_articles$description[gsm_articles$name == .x] <<- get_meta(articles[[.x]], 
-                                                                        "description")
-  gsm_articles$title[gsm_articles$name == .x] <<- get_meta(articles[[.x]],
-                                                                  "title")
-})
-
-##output names, descriptions and links
-gsm_articles %>% glue_data('- [{title}](https://openrbqm.github.io/openrbqm/articles/{name}) {description}', close='\n')
 ```
-
-## gsm.core 
-
-```{r get_gsm_articles, echo=FALSE, results = "asis"}
-
-gsm_articles <- get_articles("Gilead-BioStats","gsm")
-
-#get article text
-articles <- purrr::map(gsm_articles$download_url, \(.x) readLines(.x))
-names(articles) <- gsm_articles$name
-
-#add title and description to data
-purrr::map(names(articles), \(.x) {
-  gsm_articles$description[gsm_articles$name == .x] <<- get_meta(articles[[.x]], 
-                                                                        "description")
-  gsm_articles$title[gsm_articles$name == .x] <<- get_meta(articles[[.x]],
-                                                                  "title")
-})
-
-##output names, descriptions and links
-gsm_articles %>% glue_data('- [{title}](https://gilead-biostats.github.io/gsm/articles/{name}) {description}', close='\n')
-```
-
-# Examples


### PR DESCRIPTION
Add a `Packages` page to the OpenRBQM website that programmatically pulls metadata, articles and examples from public packages to display in a centralized location.

closes #22 