### PR TITLE
ci: switch automated update workflows to PR actions

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -3,6 +3,7 @@ on:
     branches: [main]
     paths-ignore:
       - 'README.md'
+      - '_freeze/**'
   pull_request:
     types: [opened, synchronize, reopened, closed]
   workflow_dispatch:

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
@@ -38,19 +40,16 @@ jobs:
 
       - name: Open PR if news.qmd changed
         if: steps.update.outputs.added != '0'
-        run: |
-          branch="auto/news-$(date +%Y%m%d%H%M%S)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git add news.qmd
-          git commit -m "chore: add ${{ steps.update.outputs.added }} new release(s) to News tab"
-          git push origin "$branch"
-          gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "chore: update News tab with new package releases" \
-            --body "Automated update: ${{ steps.update.outputs.added }} new release(s) added to \`news.qmd\` by the release-check workflow." \
-            --assignee nandriychuk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            news.qmd
+          branch: auto/news-update
+          branch-suffix: timestamp
+          commit-message: 'chore: add ${{ steps.update.outputs.added }} new release(s) to News tab'
+          title: 'chore: update News tab with new package releases'
+          body: 'Automated update: ${{ steps.update.outputs.added }} new release(s) added to `news.qmd` by the release-check workflow.'
+          assignees: nandriychuk
+          delete-branch: true
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/refresh_cache.yml
+++ b/.github/workflows/refresh_cache.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -55,23 +57,16 @@ jobs:
           cp -r _freeze.bak/vignettes _freeze/ 2>/dev/null || true
 
       - name: Open PR with refreshed cache
-        run: |
-          git add _freeze
-          if git diff --cached --quiet; then
-            echo "No cache changes."
-          else
-            branch="auto/refresh-cache-$(date +%Y%m%d%H%M%S)"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b "$branch"
-            git commit -m "chore: refresh package/vignette data cache"
-            git push origin "$branch"
-            gh pr create \
-              --base main \
-              --head "$branch" \
-              --title "chore: refresh package/vignette data cache" \
-              --body "Automated update: refreshed committed \`_freeze\` cache for dynamic package/vignette pages." \
-              --assignee nandriychuk
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            _freeze
+          branch: auto/refresh-cache
+          branch-suffix: timestamp
+          commit-message: 'chore: refresh package/vignette data cache'
+          title: 'chore: refresh package/vignette data cache'
+          body: 'Automated update: refreshed committed `_freeze` cache for dynamic package/vignette pages.'
+          assignees: nandriychuk
+          delete-branch: true
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary

- switch `refresh_cache` from GitHub CLI PR creation to `peter-evans/create-pull-request`
- switch `news_update` to the same non-CLI PR flow
- ignore `_freeze/**` in `build_site` push triggers to avoid duplicate deploys after cache-refresh PR merges

## Why

The scheduled refresh job was failing in the PR creation step, not during render or publish. Using `create-pull-request` removes the fragile `gh pr create` path and fits better with a protected `main` branch.

The `_freeze` cache refresh workflow still publishes the site directly to `gh-pages`, but now persists cache changes back to the repo through a reviewable PR. Ignoring `_freeze/**` in the production deploy workflow avoids a second unnecessary deploy when that PR is merged.

## Validation

- verified the updated workflow YAML files parse cleanly
- confirmed the refresh job failure was in the old PR creation path

Closes #31
