### PR TITLE
ci: use GitHub App token for create-pull-request steps

### DIFF
--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.CI_GH_APP_ID }}
           private-key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -38,10 +38,18 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CI_GH_APP_ID }}
+          private_key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
+
       - name: Open PR if news.qmd changed
         if: steps.update.outputs.added != '0'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: |
             news.qmd
           branch: auto/news-update

--- a/.github/workflows/news_update.yml
+++ b/.github/workflows/news_update.yml
@@ -40,10 +40,10 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.CI_GH_APP_ID }}
-          private_key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CI_GH_APP_ID }}
+          private-key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
 
       - name: Open PR if news.qmd changed
         if: steps.update.outputs.added != '0'

--- a/.github/workflows/refresh_cache.yml
+++ b/.github/workflows/refresh_cache.yml
@@ -56,9 +56,17 @@ jobs:
           cp -r _freeze.bak/packages _freeze/ 2>/dev/null || true
           cp -r _freeze.bak/vignettes _freeze/ 2>/dev/null || true
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CI_GH_APP_ID }}
+          private_key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
+
       - name: Open PR with refreshed cache
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: |
             _freeze
           branch: auto/refresh-cache

--- a/.github/workflows/refresh_cache.yml
+++ b/.github/workflows/refresh_cache.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.CI_GH_APP_ID }}
           private-key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/refresh_cache.yml
+++ b/.github/workflows/refresh_cache.yml
@@ -58,10 +58,10 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.CI_GH_APP_ID }}
-          private_key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CI_GH_APP_ID }}
+          private-key: ${{ secrets.CI_GH_APP_PRIVATE_KEY }}
 
       - name: Open PR with refreshed cache
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Closes #32

## Problem
Both `refresh_cache.yml` and `news_update.yml` were failing at the `peter-evans/create-pull-request` step — the default `GITHUB_TOKEN` cannot open PRs when triggered by the Actions bot.

## Changes
- Added `actions/create-github-app-token@v3` step to both workflows
- Token generated from `CI_GH_APP_ID` + `CI_GH_APP_PRIVATE_KEY` secrets
- Passed generated token to `peter-evans/create-pull-request`

Tested GHA and they ran successfully and created these PRs:
- https://github.com/OpenRBQM/OpenRBQM.github.io/pull/35
- https://github.com/OpenRBQM/OpenRBQM.github.io/pull/34